### PR TITLE
Events

### DIFF
--- a/event/event.go
+++ b/event/event.go
@@ -1,0 +1,20 @@
+/*
+ *     Proto is a minimal tool for real time HTML rendering.
+ *     Copyright (C) 2024  Dviih
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Affero General Public License as published
+ *     by the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Affero General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Affero General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package event

--- a/event/event.go
+++ b/event/event.go
@@ -72,22 +72,6 @@ func (event *Event) Run() {
 	event.running.Store(true)
 }
 
-func (event *Event) Add(attribute string, value js.Value) {
-	if event.attached {
-		panic(isAttached)
-	}
-
-	event.events.Store(attribute, value)
-}
-
-func (event *Event) Remove(attribute string) {
-	if event.attached {
-		panic(isAttached)
-	}
-
-	event.events.Delete(attribute)
-}
-
 func (event *Event) Condition(condition, expected string) {
 	if event.attached {
 		panic(isAttached)

--- a/event/event.go
+++ b/event/event.go
@@ -43,3 +43,14 @@ type Event struct {
 
 var isAttached = errors.New("event is attached")
 
+func (event *Event) Match() bool {
+	matched := true
+
+	event.conditions.Range(func(condition, expected interface{}) bool {
+		matched = !proto.Document().Call("querySelector", "["+condition.(string)+"="+expected.(string)+"]").IsNull()
+		return matched
+	})
+
+	return matched
+}
+

--- a/event/event.go
+++ b/event/event.go
@@ -138,3 +138,14 @@ func New(id string, c chan bool) *Event {
 	}
 }
 
+func Attached(value js.Value) *Event {
+	event := &Event{
+		value:    value,
+		events:   sync.Map{},
+		running:  atomic.Bool{},
+		attached: true,
+	}
+
+	event.running.Store(true)
+	return event
+}

--- a/event/event.go
+++ b/event/event.go
@@ -108,3 +108,7 @@ func (event *Event) Subscribe(name string, fn func(js.Value, []js.Value) interfa
 	}
 }
 
+func (event *Event) Unsubscribe(name string) {
+	event.events.Delete(name)
+}
+

--- a/event/event.go
+++ b/event/event.go
@@ -96,3 +96,15 @@ func (event *Event) Condition(condition, expected string) {
 	event.conditions.Store(html.EscapeString(condition), html.EscapeString(expected))
 }
 
+func (event *Event) Subscribe(name string, fn func(js.Value, []js.Value) interface{}) {
+	event.events.Store(name, js.FuncOf(fn))
+
+	if event.c != nil {
+		event.c <- true
+	}
+
+	if event.attached {
+		event.Run()
+	}
+}
+

--- a/event/event.go
+++ b/event/event.go
@@ -80,3 +80,11 @@ func (event *Event) Add(attribute string, value js.Value) {
 	event.events.Store(attribute, value)
 }
 
+func (event *Event) Remove(attribute string) {
+	if event.attached {
+		panic(isAttached)
+	}
+
+	event.events.Delete(attribute)
+}
+

--- a/event/event.go
+++ b/event/event.go
@@ -41,3 +41,5 @@ type Event struct {
 	attached bool
 }
 
+var isAttached = errors.New("event is attached")
+

--- a/event/event.go
+++ b/event/event.go
@@ -88,3 +88,11 @@ func (event *Event) Remove(attribute string) {
 	event.events.Delete(attribute)
 }
 
+func (event *Event) Condition(condition, expected string) {
+	if event.attached {
+		panic(isAttached)
+	}
+
+	event.conditions.Store(html.EscapeString(condition), html.EscapeString(expected))
+}
+

--- a/event/event.go
+++ b/event/event.go
@@ -93,7 +93,16 @@ func (event *Event) Subscribe(name string, fn func(js.Value, []js.Value) interfa
 }
 
 func (event *Event) Unsubscribe(name string) {
-	event.events.Delete(name)
+	if !event.Value().IsNull() {
+		event.Value().Call("removeEventListener", name)
+	}
+
+	fn, ok := event.events.LoadAndDelete(name)
+	if !ok {
+		return
+	}
+
+	fn.(js.Func).Release()
 }
 
 func (event *Event) Running() bool {

--- a/event/event.go
+++ b/event/event.go
@@ -112,3 +112,7 @@ func (event *Event) Unsubscribe(name string) {
 	event.events.Delete(name)
 }
 
+func (event *Event) Running() bool {
+	return event.running.Load()
+}
+

--- a/event/event.go
+++ b/event/event.go
@@ -54,3 +54,21 @@ func (event *Event) Match() bool {
 	return matched
 }
 
+func (event *Event) Run() {
+	if !event.attached {
+		event.forceValue()
+
+		if !event.Match() {
+			event.running.Store(false)
+			return
+		}
+	}
+
+	event.events.Range(func(name, fn any) bool {
+		event.Value().Call("addEventListener", name, fn)
+		return true
+	})
+
+	event.running.Store(true)
+}
+

--- a/event/event.go
+++ b/event/event.go
@@ -18,3 +18,13 @@
  */
 
 package event
+
+import (
+	"errors"
+	"github.com/Dviih/proto"
+	"html"
+	"sync"
+	"sync/atomic"
+	"syscall/js"
+)
+

--- a/event/event.go
+++ b/event/event.go
@@ -72,3 +72,11 @@ func (event *Event) Run() {
 	event.running.Store(true)
 }
 
+func (event *Event) Add(attribute string, value js.Value) {
+	if event.attached {
+		panic(isAttached)
+	}
+
+	event.events.Store(attribute, value)
+}
+

--- a/event/event.go
+++ b/event/event.go
@@ -28,3 +28,16 @@ import (
 	"syscall/js"
 )
 
+type Event struct {
+	id    string
+	value js.Value
+
+	conditions sync.Map
+	events     sync.Map
+
+	running atomic.Bool
+	c       chan bool
+
+	attached bool
+}
+

--- a/event/event.go
+++ b/event/event.go
@@ -128,3 +128,13 @@ func (event *Event) forceValue() {
 	event.value = proto.Document().Call("getElementById", event.id)
 }
 
+func New(id string, c chan bool) *Event {
+	return &Event{
+		id:         id,
+		conditions: sync.Map{},
+		events:     sync.Map{},
+		running:    atomic.Bool{},
+		c:          c,
+	}
+}
+

--- a/event/event.go
+++ b/event/event.go
@@ -116,3 +116,11 @@ func (event *Event) Running() bool {
 	return event.running.Load()
 }
 
+func (event *Event) Value() js.Value {
+	if event.value.IsUndefined() {
+		event.forceValue()
+	}
+
+	return event.value
+}
+

--- a/event/event.go
+++ b/event/event.go
@@ -124,3 +124,7 @@ func (event *Event) Value() js.Value {
 	return event.value
 }
 
+func (event *Event) forceValue() {
+	event.value = proto.Document().Call("getElementById", event.id)
+}
+

--- a/global.go
+++ b/global.go
@@ -1,5 +1,5 @@
 /*
- *     An easy way to provide conectivity across multiple servers.
+ *     Proto is a minimal tool for real time HTML rendering.
  *     Copyright (C) 2024  Dviih
  *
  *     This program is free software: you can redistribute it and/or modify

--- a/pkg/server/main.go
+++ b/pkg/server/main.go
@@ -1,5 +1,5 @@
 /*
- *     An easy way to provide conectivity across multiple servers.
+ *     Proto is a minimal tool for real time HTML rendering.
  *     Copyright (C) 2024  Dviih
  *
  *     This program is free software: you can redistribute it and/or modify

--- a/pkg/server/public/index.html
+++ b/pkg/server/public/index.html
@@ -1,5 +1,5 @@
 <!--
-  ~     An easy way to provide conectivity across multiple servers.
+  ~     Proto is a minimal tool for real time HTML rendering.
   ~     Copyright (C) 2024  Dviih
   ~
   ~     This program is free software: you can redistribute it and/or modify

--- a/proto.go
+++ b/proto.go
@@ -1,5 +1,5 @@
 /*
- *     An easy way to provide conectivity across multiple servers.
+ *     Proto is a minimal tool for real time HTML rendering.
  *     Copyright (C) 2024  Dviih
  *
  *     This program is free software: you can redistribute it and/or modify

--- a/render/element.go
+++ b/render/element.go
@@ -1,5 +1,5 @@
 /*
- *     An easy way to provide conectivity across multiple servers.
+ *     Proto is a minimal tool for real time HTML rendering.
  *     Copyright (C) 2024  Dviih
  *
  *     This program is free software: you can redistribute it and/or modify

--- a/render/render.go
+++ b/render/render.go
@@ -120,9 +120,14 @@ func New(fs embed.FS, patterns ...string) (*Render, error) {
 		return nil, err
 	}
 
-	return &Render{
+	render := &Render{
 		template: t,
 		m:        sync.Mutex{},
 		data:     make(map[string]interface{}),
-	}, nil
+		events:   sync.Map{},
+		c:        make(chan bool),
+	}
+
+	go render.hook()
+	return render, nil
 }

--- a/render/render.go
+++ b/render/render.go
@@ -1,5 +1,5 @@
 /*
- *     An easy way to provide conectivity across multiple servers.
+ *     Proto is a minimal tool for real time HTML rendering.
  *     Copyright (C) 2024  Dviih
  *
  *     This program is free software: you can redistribute it and/or modify
@@ -20,8 +20,10 @@
 package render
 
 import (
+	"bytes"
 	"embed"
 	"github.com/Dviih/proto"
+	"github.com/Dviih/proto/event"
 	"html/template"
 	"sync"
 	"syscall/js"
@@ -33,6 +35,10 @@ type Render struct {
 
 	m    sync.Mutex
 	data map[string]interface{}
+
+	events sync.Map
+	c      chan bool
+
 }
 
 func (render *Render) Add(key string, value interface{}) {

--- a/render/render.go
+++ b/render/render.go
@@ -102,6 +102,18 @@ func (render *Render) Create(name string) (*Element, error) {
 	return element, nil
 }
 
+func (render *Render) hook() {
+	for {
+		select {
+		case <-render.c:
+			render.events.Range(func(_, e interface{}) bool {
+				e.(*event.Event).Run()
+				return true
+			})
+		}
+	}
+}
+
 func New(fs embed.FS, patterns ...string) (*Render, error) {
 	t, err := template.ParseFS(fs, patterns...)
 	if err != nil {

--- a/render/render.go
+++ b/render/render.go
@@ -77,6 +77,13 @@ func (render *Render) Root() *Element {
 	return render.root
 }
 
+func (render *Render) Event(id string) *event.Event {
+	e := event.New(id, render.c)
+
+	render.events.Store(id, e)
+	return e
+}
+
 func (render *Render) Execute(name string) error {
 	return render.template.ExecuteTemplate(render.Root(), name, render.data)
 }


### PR DESCRIPTION
This pull request implements events for proto.

The event struct holds an id which must exist now or later.
An event might have some conditions to run which should be dealt by `querySelector`.
An event must only run if every condition is matched.

Subscribe and Unsubscribe are `addEventListener` and `removeEventListener` respectively.