### PR TITLE
Router

### DIFF
--- a/router/page.go
+++ b/router/page.go
@@ -31,3 +31,6 @@ type Page struct {
 	Query     map[string]string
 }
 
+func (page *Page) Logger() *slog.Logger {
+	return page.logger
+}

--- a/router/page.go
+++ b/router/page.go
@@ -1,0 +1,25 @@
+/*
+ *     Proto is a minimal tool for real time HTML rendering.
+ *     Copyright (C) 2024  Dviih
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Affero General Public License as published
+ *     by the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Affero General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Affero General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package router
+
+import (
+	"log/slog"
+)
+

--- a/router/page.go
+++ b/router/page.go
@@ -23,3 +23,11 @@ import (
 	"log/slog"
 )
 
+type Page struct {
+	template string
+	logger   *slog.Logger
+
+	Arguments []string
+	Query     map[string]string
+}
+

--- a/router/router.go
+++ b/router/router.go
@@ -23,3 +23,5 @@ import (
 	"github.com/Dviih/Map"
 )
 
+type Handler func(*Page) error
+

--- a/router/router.go
+++ b/router/router.go
@@ -1,0 +1,25 @@
+/*
+ *     Proto is a minimal tool for real time HTML rendering.
+ *     Copyright (C) 2024  Dviih
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Affero General Public License as published
+ *     by the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Affero General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Affero General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package router
+
+import (
+	"github.com/Dviih/Map"
+)
+

--- a/router/router.go
+++ b/router/router.go
@@ -47,3 +47,44 @@ func (router *Router) Get(route string) (Handler, error) {
 	return nil, Map.KeyNotFound
 }
 
+func (router *Router) match(name string) Handler {
+	var ret Handler
+
+	router.pages.Range(func(s string, handler Handler) bool {
+		route := split(s, '/')
+		ns := split(name, '/')
+
+		if len(ns) > len(route) {
+			return false
+		}
+
+		for i, r := range route {
+			if len(ns) >= i && len(ns[i]) == 0 {
+				ret = nil
+				return false
+			}
+
+			if len(r) == 0 || r[0] == ':' {
+				if len(ns) < i+1 {
+					ret = nil
+				}
+				continue
+			}
+
+			if len(ns) < i {
+				return true
+			}
+
+			if ns[i] == r {
+				ret = handler
+			} else {
+				return true
+			}
+		}
+
+		return true
+	})
+
+	return ret
+}
+

--- a/router/router.go
+++ b/router/router.go
@@ -30,3 +30,7 @@ type Router struct {
 	_default string
 }
 
+func (router *Router) Add(route string, handler Handler) {
+	router.pages.Store(route, handler)
+}
+

--- a/router/router.go
+++ b/router/router.go
@@ -25,3 +25,8 @@ import (
 
 type Handler func(*Page) error
 
+type Router struct {
+	pages    *Map.Map[string, Handler]
+	_default string
+}
+

--- a/router/router.go
+++ b/router/router.go
@@ -34,3 +34,7 @@ func (router *Router) Add(route string, handler Handler) {
 	router.pages.Store(route, handler)
 }
 
+func (router *Router) Remove(route string) {
+	router.pages.Delete(route)
+}
+

--- a/router/router.go
+++ b/router/router.go
@@ -106,3 +106,8 @@ func split(s string, b byte) []string {
 	return append(ret, s[j:])
 }
 
+func New() *Router {
+	return &Router{
+		pages: Map.New[string, Handler](),
+	}
+}

--- a/router/router.go
+++ b/router/router.go
@@ -88,3 +88,21 @@ func (router *Router) match(name string) Handler {
 	return ret
 }
 
+func split(s string, b byte) []string {
+	var ret []string
+	j := 1
+
+	for i := 1; i < len(s); i++ {
+		if s[i] == b {
+			ret = append(ret, s[j:i])
+			j = i + 1
+		}
+	}
+
+	if j-len(s) == 0 {
+		return ret
+	}
+
+	return append(ret, s[j:])
+}
+

--- a/router/router.go
+++ b/router/router.go
@@ -38,3 +38,12 @@ func (router *Router) Remove(route string) {
 	router.pages.Delete(route)
 }
 
+func (router *Router) Get(route string) (Handler, error) {
+	handler := router.match(route)
+	if handler != nil {
+		return handler, nil
+	}
+
+	return nil, Map.KeyNotFound
+}
+


### PR DESCRIPTION
Implements router as given in #12.

---

Router.Add adds a new route with handler.
Router.Remove removes a route by pattern (not if matches).
Router.Get gets a route by matching pattern.
New creates a new Router.

---

Router.match matches the pattern given the name and returns the handler.
split splits the path.

---

Given `/path` only `/path` will match
Given `/path/:arg`, `/path/a`, `/path/b` will match but not `/path` and `/path/a/b`.