### PR TITLE
Proto: Store

### DIFF
--- a/store.go
+++ b/store.go
@@ -1,0 +1,26 @@
+/*
+ *     Proto is a minimal tool for real time HTML rendering.
+ *     Copyright (C) 2024  Dviih
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Affero General Public License as published
+ *     by the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Affero General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Affero General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package proto
+
+import (
+	"sync"
+	"sync/atomic"
+)
+

--- a/store.go
+++ b/store.go
@@ -31,3 +31,35 @@ type Store interface {
 	Delete(string)
 }
 
+type MapStore struct {
+	m sync.Map
+}
+
+func (store *MapStore) Set(key string, value interface{}) {
+	store.m.Store(key, value)
+}
+
+func (store *MapStore) Get(key string) interface{} {
+	v, ok := store.m.Load(key)
+	if !ok {
+		return nil
+	}
+
+	return v
+}
+
+func (store *MapStore) Range(fn func(string, interface{}) bool) {
+	store.m.Range(func(key, value any) bool {
+		s, ok := key.(string)
+		if !ok {
+			return false
+		}
+
+		return fn(s, value)
+	})
+}
+
+func (store *MapStore) Delete(key string) {
+	store.Delete(key)
+}
+

--- a/store.go
+++ b/store.go
@@ -63,3 +63,28 @@ func (store *MapStore) Delete(key string) {
 	store.Delete(key)
 }
 
+type AnyStore struct {
+	m atomic.Pointer[interface{}]
+}
+
+func (store *AnyStore) Set(_ string, v interface{}) {
+	store.m.Store(&v)
+}
+
+func (store *AnyStore) Get(_ string) interface{} {
+	v := store.m.Load()
+	if v == nil {
+		return nil
+	}
+
+	return *v
+}
+
+func (store *AnyStore) Range(fn func(string, interface{}) bool) {
+	_ = fn("", store.Get(""))
+}
+
+func (store *AnyStore) Delete(_ string) {
+	store.m.Store(nil)
+}
+

--- a/store.go
+++ b/store.go
@@ -88,3 +88,17 @@ func (store *AnyStore) Delete(_ string) {
 	store.m.Store(nil)
 }
 
+func ToStore(v interface{}) Store {
+	switch v := v.(type) {
+	case *MapStore:
+		return v
+	case *AnyStore:
+		return v
+	default:
+		store := &AnyStore{}
+
+		store.Set("", v)
+		return store
+	}
+}
+

--- a/store.go
+++ b/store.go
@@ -24,3 +24,10 @@ import (
 	"sync/atomic"
 )
 
+type Store interface {
+	Set(string, interface{})
+	Get(string) interface{}
+	Range(func(string, interface{}) bool)
+	Delete(string)
+}
+

--- a/store.go
+++ b/store.go
@@ -104,3 +104,22 @@ func ToStore(v interface{}) Store {
 	}
 }
 
+func MapStoreFrom(v interface{}) *MapStore {
+	store := &MapStore{}
+
+	switch v := v.(type) {
+	case map[string]interface{}:
+		for key, value := range v {
+			store.Set(key, value)
+		}
+	case *MapStore:
+		v.Range(func(key string, value interface{}) bool {
+			store.Set(key, value)
+			return true
+		})
+	default:
+		panic("invalid map from")
+	}
+
+	return store
+}

--- a/store.go
+++ b/store.go
@@ -94,6 +94,8 @@ func ToStore(v interface{}) Store {
 		return v
 	case *AnyStore:
 		return v
+	case map[string]interface{}:
+		return MapStoreFrom(v)
 	default:
 		store := &AnyStore{}
 


### PR DESCRIPTION
As described on #20, this pull request brings the new `proto.Store` utility with a couple of implementations.
The first one is `MapStore` which is based on top of `sync.Map` and the successor of the previous used in `template`, the second is `AnyStore` which stores any value and gets it by any name and deletes will delete it. The `AnyStore` is based on top of `atomic.Pointer[T]`, which get may return nil.
Template and router will implement it by its own pull request.